### PR TITLE
Add line about sBTC to readme

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -9,6 +9,9 @@
 
 📚 Learn more about building on Bitcoin via Stacks: [Primer](https://www.stacks.co/build/get-started), [Docs](https://docs.stacks.co/docs/intro).
 
+1️⃣:1️⃣ Explore the 1:1 Bitcoin peg on Stacks: [sBTC development](https://github.com/stacks-sbtc)
+
+
 🆕 Find the latest news: [Hourly](https://twitter.com/stacks), [Daily](https://stacks.co/blog), [Weekly](https://stackssnacks.com/), [Monthly](https://newsletters.stacks.org/)
 
 🌱 Learn more about funding and support for your Stacks project: [Fuel your project](https://www.stacks.co/build/fuel-your-project).

--- a/profile/README.md
+++ b/profile/README.md
@@ -11,7 +11,6 @@
 
 1️⃣:1️⃣ Explore the 1:1 Bitcoin peg on Stacks: [sBTC development](https://github.com/stacks-sbtc)
 
-
 🆕 Find the latest news: [Hourly](https://twitter.com/stacks), [Daily](https://stacks.co/blog), [Weekly](https://stackssnacks.com/), [Monthly](https://newsletters.stacks.org/)
 
 🌱 Learn more about funding and support for your Stacks project: [Fuel your project](https://www.stacks.co/build/fuel-your-project).

--- a/profile/README.md
+++ b/profile/README.md
@@ -9,7 +9,7 @@
 
 📚 Learn more about building on Bitcoin via Stacks: [Primer](https://www.stacks.co/build/get-started), [Docs](https://docs.stacks.co/docs/intro).
 
-1️⃣:1️⃣ Explore the 1:1 Bitcoin peg on Stacks: [sBTC development](https://github.com/stacks-sbtc)
+🔗 Explore the 1:1 Bitcoin peg on Stacks: [sBTC development](https://github.com/stacks-sbtc)
 
 🆕 Find the latest news: [Hourly](https://twitter.com/stacks), [Daily](https://stacks.co/blog), [Weekly](https://stackssnacks.com/), [Monthly](https://newsletters.stacks.org/)
 


### PR DESCRIPTION
## Description

This PR adds link to sBTC github org to profile README.

1. Needed to keep connection after sBTC project migration to new repo.
2. Added one new line to profile README
3. This will allow to find sBTC project more easily
